### PR TITLE
Set page titles per route

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,17 +2,22 @@ import { Routes } from '@angular/router';
 export const routes: Routes = [
   {
     path: 'about',
+    title: 'Acerca de Sleepy Zuzki - Desarrollo Web y Streaming',
     loadComponent: () => import('@pages/about.page').then(m => m.AboutPage)
   },
   {
     path: 'works',
+    title: 'Proyectos de Sleepy Zuzki - Soluciones Interactivas',
     loadComponent: () => import('@pages/works.page').then(m => m.WorksPage)
   },
   {
     path: 'works/:id',
+    title: 'Detalle de Proyecto - Sleepy Zuzki',
     loadComponent: () => import('@pages/work-details.page').then(m => m.WorkDetailsPage)
   },
-  { path: '',
+  {
+    path: '',
+    title: 'Portafolio de Sleepy Zuzki - Inicio',
     loadComponent: () => import('@pages/home.page').then(m => m.HomePage)
   }
 ];


### PR DESCRIPTION
## Summary
- add 60-char titles for each page

## Testing
- `pnpm run test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684f5ca5bdd483259bcaf7028491f7f5