### PR TITLE
Add SEO page metadata

### DIFF
--- a/src/app/core/constants/page-meta.ts
+++ b/src/app/core/constants/page-meta.ts
@@ -1,0 +1,29 @@
+import { PageMeta } from '../interfaces/page-meta.interface';
+
+export const PAGE_META: PageMeta[] = [
+  {
+    path: '/',
+    description: 'Explora Sleepy Zuzki y su enfoque creativo en diseño web. Conoce proyectos destacados, mejora la experiencia digital y encuentra inspiración para tu próxima idea.',
+    keywords: ['sleepy zuzki', 'diseño web', 'experiencia digital', 'portafolio']
+  },
+  {
+    path: '/portfolio',
+    description: 'Explora el portafolio de Sleepy Zuzki y descubre proyectos de UI y UX que combinan creatividad y funcion. Inspírate con soluciones visuales para impulsar tus ideas.',
+    keywords: ['sleepy zuzki', 'ui ux', 'diseno', 'portafolio', 'proyectos']
+  },
+  {
+    path: '/blog',
+    description: 'Visita el blog de Sleepy Zuzki para aprender diseño web y desarrollo con consejos prácticos. Disfruta artículos y tutoriales que enriquecerán tus proyectos.',
+    keywords: ['sleepy zuzki', 'blog desarrollo', 'tutoriales', 'diseño web', 'consejos']
+  },
+  {
+    path: '/contacto',
+    description: 'Habla con Sleepy Zuzki para iniciar colaboraciones o pedir consultoría web. Comparte tu proyecto y recibe guía personalizada que impulse resultados impactantes.',
+    keywords: ['sleepy zuzki', 'consultoria web', 'colaboraciones', 'contacto', 'proyecto']
+  },
+  {
+    path: '/404',
+    description: 'La página que buscas no existe. Sleepy Zuzki te invita a seguir navegando, conocer proyectos y servicios de diseño web que pueden inspirarte a crear algo nuevo.',
+    keywords: ['sleepy zuzki', 'pagina no encontrada', 'error 404', 'diseño web']
+  }
+];

--- a/src/app/core/interfaces/page-meta.interface.ts
+++ b/src/app/core/interfaces/page-meta.interface.ts
@@ -1,0 +1,11 @@
+/**
+ * Representa las etiquetas meta para cada ruta.
+ */
+export interface PageMeta {
+  /** Ruta relativa asociada al conjunto de metadatos. */
+  path: string;
+  /** Descripción breve optimizada para SEO. */
+  description: string;
+  /** Palabras clave relevantes para la página. */
+  keywords: string[];
+}


### PR DESCRIPTION
## Summary
- add `PageMeta` interface for SEO metadata
- add `PAGE_META` constant with Spanish descriptions and keywords

## Testing
- `pnpm run test` *(fails: Chrome missing)*

------
https://chatgpt.com/codex/tasks/task_e_685072f1acec8325967b71427cbbd11b